### PR TITLE
Fix compiler void* assignment to XML_Char* error

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -7422,7 +7422,7 @@ copyString(const XML_Char *s, const XML_Memory_Handling_Suite *memsuite) {
   charsRequired++;
 
   /* Now allocate space for the copy */
-  result = memsuite->malloc_fcn(charsRequired * sizeof(XML_Char));
+  result = (XML_Char *)memsuite->malloc_fcn(charsRequired * sizeof(XML_Char));
   if (result == NULL)
     return NULL;
   /* Copy the original into place */


### PR DESCRIPTION
I've attempted to build the library but the Intel compiler complains:

```
xmlparse.c(7425): error: a value of type "void *" cannot be assigned to an entity of type "XML_Char={char} *"
    result = memsuite->malloc_fcn(charsRequired * sizeof(XML_Char));
```

This is the only occurrence where memory is not cased to the target type. So it seems reasonable to ensure this doesn't result in errors in some environments.